### PR TITLE
Add support for stm32f401

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ version = "0.2.3"
 [features]
 default = ["rt", "stm32f407"]
 rt = []
+stm32f401 = ["stm32f4/stm32f401"]
 stm32f407 = ["stm32f4/stm32f407"]
 stm32f429 = ["stm32f4/stm32f429"]
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -567,6 +567,7 @@ gpio!(GPIOE, gpioe, gpioeen, PE, [
     PE15: (pe15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 gpio!(GPIOF, gpiof, gpiofen, PF, [
     PF0: (pf0, 0, Input<Floating>),
     PF1: (pf1, 1, Input<Floating>),
@@ -586,6 +587,7 @@ gpio!(GPIOF, gpiof, gpiofen, PF, [
     PF15: (pf15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 gpio!(GPIOG, gpiog, gpiogen, PG, [
     PG0: (pg0, 0, Input<Floating>),
     PG1: (pg1, 1, Input<Floating>),
@@ -605,6 +607,7 @@ gpio!(GPIOG, gpiog, gpiogen, PG, [
     PG15: (pg15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 gpio!(GPIOH, gpioh, gpiohen, PH, [
     PH0: (ph0, 0, Input<Floating>),
     PH1: (ph1, 1, Input<Floating>),
@@ -624,6 +627,7 @@ gpio!(GPIOH, gpioh, gpiohen, PH, [
     PH15: (ph15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 gpio!(GPIOI, gpioi, gpioien, PI, [
     PI0: (pi0, 0, Input<Floating>),
     PI1: (pi1, 1, Input<Floating>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub extern crate nb;
 pub use nb::block;
 pub extern crate stm32f4;
 
+#[cfg(feature = "stm32f401")]
+pub use stm32f4::stm32f401 as stm32;
+
 #[cfg(feature = "stm32f407")]
 pub use stm32f4::stm32f407 as stm32;
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -123,6 +123,9 @@ impl CFGR {
                 sysclk: Hertz(sysclk),
             }
         } else {
+            #[cfg(feature = "stm32f401")]
+            assert!(sysclk <= 84_000_000 && sysclk >= 24_000_000);
+
             #[cfg(feature = "stm32f407")]
             assert!(sysclk <= 168_000_000 && sysclk >= 24_000_000);
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,13 +6,21 @@ use hal;
 use hal::prelude::*;
 use nb;
 
+#[cfg(feature = "stm32f401")]
+use stm32::{RCC, USART1, USART2, USART6};
+
 #[cfg(feature = "stm32f407")]
 use stm32::{RCC, UART4, UART5, USART1, USART2, USART3, USART6};
 
 #[cfg(feature = "stm32f429")]
 use stm32::{RCC, UART4, UART5, UART7, UART8, USART1, USART2, USART3, USART6};
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 use stm32::usart6::cr2::STOPW;
+
+#[cfg(feature = "stm32f401")]
+use stm32::usart1::cr2::STOPW;
+
 
 use gpio::gpioa::{PA0, PA1, PA10, PA2, PA3, PA9};
 use gpio::gpiob::{PB10, PB11, PB6, PB7};
@@ -22,6 +30,7 @@ use gpio::gpiod::{PD2, PD5, PD6, PD8, PD9};
 use gpio::gpioe::{PE0, PE1};
 #[cfg(feature = "stm32f429")]
 use gpio::gpiof::{PF6, PF7};
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 use gpio::gpiog::{PG14, PG9};
 use gpio::{Alternate, AF7, AF8};
 use rcc::Clocks;
@@ -136,16 +145,23 @@ impl Pins<USART1> for (PB6<Alternate<AF7>>, PB7<Alternate<AF7>>) {}
 impl Pins<USART2> for (PA2<Alternate<AF7>>, PA3<Alternate<AF7>>) {}
 impl Pins<USART2> for (PD5<Alternate<AF7>>, PD6<Alternate<AF7>>) {}
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<USART3> for (PB10<Alternate<AF7>>, PB11<Alternate<AF7>>) {}
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<USART3> for (PC10<Alternate<AF7>>, PC11<Alternate<AF7>>) {}
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<USART3> for (PD8<Alternate<AF7>>, PD9<Alternate<AF7>>) {}
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<UART4> for (PA0<Alternate<AF8>>, PA1<Alternate<AF8>>) {}
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<UART4> for (PC10<Alternate<AF8>>, PC11<Alternate<AF8>>) {}
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<UART5> for (PC12<Alternate<AF8>>, PD2<Alternate<AF8>>) {}
 
 impl Pins<USART6> for (PC6<Alternate<AF8>>, PC7<Alternate<AF8>>) {}
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl Pins<USART6> for (PG14<Alternate<AF8>>, PG9<Alternate<AF8>>) {}
 
 #[cfg(feature = "stm32f429")]
@@ -422,7 +438,9 @@ impl hal::serial::Write<u8> for Tx<USART2> {
     }
 }
 
+
 /// USART3
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl<PINS> Serial<USART3, PINS> {
     pub fn usart3(usart: USART3, pins: PINS, baud_rate: Bps, clocks: Clocks) -> Self
     where
@@ -469,6 +487,7 @@ impl<PINS> Serial<USART3, PINS> {
     }
 }
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl hal::serial::Read<u8> for Rx<USART3> {
     type Error = Error;
 
@@ -502,6 +521,7 @@ impl hal::serial::Read<u8> for Rx<USART3> {
     }
 }
 
+#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 impl hal::serial::Write<u8> for Tx<USART3> {
     type Error = Error;
 


### PR DESCRIPTION
Add support for the stm32f401 MCU.

Tested with my BSP repo for the nucleo-f401re board.  - https://github.com/jkristell/nucleo-f401re

Peripherals that is known to be working:
GPIO
Serial - Tested with different baud rates at different MCU frequencies.
