### PR TITLE
rcc: keep the cache bits in FLASH_ACR intact

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -196,7 +196,7 @@ impl CFGR {
 
             // Adjust flash wait states
             unsafe {
-                flash.acr.write(|w| {
+                flash.acr.modify(|_, w| {
                     w.latency().bits(if sysclk <= 30_000_000 {
                         0b0000
                     } else if sysclk <= 60_000_000 {


### PR DESCRIPTION
This allows configuring the cache bits independent of clock freeze.

An alternative would be to switch the caches on in here?