### PR TITLE
Allow compiling without any feature selected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ version = "0.2.2"
 version = "0.3.2"
 
 [features]
-default = ["rt"]
 rt = ["stm32f4/rt"]
 stm32f401 = ["stm32f4/stm32f401"]
 stm32f407 = ["stm32f4/stm32f407"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use stm32f4::stm32f412 as stm32;
 pub use stm32f4::stm32f429 as stm32;
 
 // Enable use of interrupt macro
+#[cfg(feature = "rt")]
 pub use stm32f4::interrupt;
 
 pub mod delay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,18 @@ pub use stm32f4::stm32f429 as stm32;
 #[cfg(feature = "rt")]
 pub use stm32f4::interrupt;
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod delay;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod gpio;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod i2c;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod prelude;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod rcc;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod serial;
 pub mod time;
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
 pub mod timer;


### PR DESCRIPTION
This fixes `cargo publish`.

The last patch may not be the prettiest but it makes some sens anyway.