### PR TITLE
SPI: Add SPI4/5/6 support

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -403,3 +403,16 @@ hal! {
     SPI2: (spi2, apb1enr, spi2en, pclk1),
     SPI3: (spi3, apb1enr, spi3en, pclk1),
 }
+
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+hal! {
+    SPI4: (spi4, apb2enr, spi4en, pclk2),
+}
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+hal! {
+    SPI5: (spi5, apb2enr, spi5en, pclk2),
+}
+#[cfg(feature = "stm32f429")]
+hal! {
+    SPI6: (spi6, apb2enr, spi6en, pclk2),
+}


### PR DESCRIPTION
This adds SPI 4, 5, and 6 to all chips that support them now that `stm32f4` has the correct RCC bits.