### PR TITLE
Add support for all existing stm32f4 devices

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -514,6 +514,7 @@ macro_rules! gpio {
     }
 }
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOA, gpioa, gpioaen, PA, [
     PA0: (pa0, 0, Input<Floating>),
     PA1: (pa1, 1, Input<Floating>),
@@ -533,6 +534,7 @@ gpio!(GPIOA, gpioa, gpioaen, PA, [
     PA15: (pa15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOB, gpiob, gpioben, PB, [
     PB0: (pb0, 0, Input<Floating>),
     PB1: (pb1, 1, Input<Floating>),
@@ -552,6 +554,7 @@ gpio!(GPIOB, gpiob, gpioben, PB, [
     PB15: (pb15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOC, gpioc, gpiocen, PC, [
     PC0: (pc0, 0, Input<Floating>),
     PC1: (pc1, 1, Input<Floating>),
@@ -571,6 +574,7 @@ gpio!(GPIOC, gpioc, gpiocen, PC, [
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOD, gpiod, gpioden, PD, [
     PD0: (pd0, 0, Input<Floating>),
     PD1: (pd1, 1, Input<Floating>),
@@ -590,6 +594,7 @@ gpio!(GPIOD, gpiod, gpioden, PD, [
     PD15: (pd15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOE, gpioe, gpioeen, PE, [
     PE0: (pe0, 0, Input<Floating>),
     PE1: (pe1, 1, Input<Floating>),
@@ -609,7 +614,7 @@ gpio!(GPIOE, gpioe, gpioeen, PE, [
     PE15: (pe15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOF, gpiof, gpiofen, PF, [
     PF0: (pf0, 0, Input<Floating>),
     PF1: (pf1, 1, Input<Floating>),
@@ -629,7 +634,7 @@ gpio!(GPIOF, gpiof, gpiofen, PF, [
     PF15: (pf15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOG, gpiog, gpiogen, PG, [
     PG0: (pg0, 0, Input<Floating>),
     PG1: (pg1, 1, Input<Floating>),
@@ -649,7 +654,7 @@ gpio!(GPIOG, gpiog, gpiogen, PG, [
     PG15: (pg15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOH, gpioh, gpiohen, PH, [
     PH0: (ph0, 0, Input<Floating>),
     PH1: (ph1, 1, Input<Floating>),
@@ -675,7 +680,7 @@ gpio!(GPIOH, gpioh, gpiohen, PH, [
     PH1: (ph1, 1, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f415", feature = "stm32f417", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 gpio!(GPIOI, gpioi, gpioien, PI, [
     PI0: (pi0, 0, Input<Floating>),
     PI1: (pi1, 1, Input<Floating>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod gpio;
 pub mod i2c;
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod prelude;
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod rcc;
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod serial;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub mod prelude;
 pub mod rcc;
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod serial;
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod spi;
 pub mod time;
 #[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use stm32f4::stm32f411 as stm32;
 #[cfg(feature = "rt")]
 pub use stm32f4::interrupt;
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod delay;
 #[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod gpio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ pub mod serial;
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod spi;
 pub mod time;
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod timer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use stm32f4::interrupt;
 
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod delay;
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pub mod gpio;
 #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
 pub mod i2c;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -114,19 +114,22 @@ impl CFGR {
                 sysclk: Hertz(sysclk),
             }
         } else {
-            #[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+            #[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
             let sysclk_min = 24_000_000;
+
+            #[cfg(any(feature = "stm32f446"))]
+            let sysclk_min = 12_500_000;
 
             #[cfg(feature = "stm32f401")]
             let sysclk_max = 84_000_000;
 
-            #[cfg(feature = "stm32f407")]
+            #[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f415", feature = "stm32f417"))]
             let sysclk_max = 168_000_000;
 
-            #[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
+            #[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
             let sysclk_max = 100_000_000;
-            
-            #[cfg(feature = "stm32f429")]
+
+            #[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
             let sysclk_max = 180_000_000;
 
             assert!(sysclk <= sysclk_max && sysclk >= sysclk_min);
@@ -161,10 +164,16 @@ impl CFGR {
             let pclk1 = hclk / ppre1 as u32;
             let pclk2 = hclk / ppre2 as u32;
 
+            #[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f415", feature = "stm32f417", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+            let flash_latency_step = 30_000_000;
+
+            #[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
+            let flash_latency_step = 25_000_000;
+
             // Adjust flash wait states
             unsafe {
                 flash.acr.modify(|_, w| {
-                    w.latency().bits(((sysclk - 1) / 30_000_000) as u8)
+                    w.latency().bits(((sysclk - 1) / flash_latency_step) as u8)
                 })
             }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,59 +4,68 @@ use hal;
 pub use hal::spi::{Mode, Phase, Polarity};
 use nb;
 
-#[cfg(feature = "stm32f401")]
-use stm32::{RCC, SPI1, SPI2, SPI3, SPI4};
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use stm32::{RCC, SPI1, SPI2};
 
-#[cfg(feature = "stm32f407")]
-use stm32::{RCC, SPI1, SPI2, SPI3};
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use stm32::{SPI3};
 
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
-use stm32::{RCC, SPI1, SPI2, SPI3, SPI4, SPI5};
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use stm32::{SPI4};
 
-#[cfg(feature = "stm32f429")]
-use stm32::{RCC, SPI1, SPI2, SPI3, SPI4, SPI5, SPI6};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use stm32::{SPI5};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f429"))]
+use stm32::{SPI6};
+
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 use gpio::gpioa::{PA5, PA6, PA7};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpioa::{PA10, PA12};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpioa::{PA1, PA11};
 
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
-use gpio::gpioa::{PA1, PA10, PA11, PA12, PA5, PA6, PA7};
-
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 use gpio::gpiob::{PB10, PB13, PB14, PB15, PB3, PB4, PB5};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpiob::{PB0};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpiob::{PB8};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpiob::{PB12};
 
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
-use gpio::gpiob::{PB0, PB10, PB12, PB13, PB14, PB15, PB3, PB4, PB5, PB8};
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use gpio::gpioc::{PC2, PC3};
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+use gpio::gpioc::{PC10, PC11, PC12};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::gpioc::{PC7};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f429"))]
-use gpio::gpioc::{PC10, PC11, PC12, PC2, PC3};
-
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
-use gpio::gpioc::{PC10, PC11, PC12, PC2, PC3, PC7};
-
-#[cfg(any(feature = "stm32f401", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 use gpio::gpiod::{PD3, PD6};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 use gpio::gpioe::{PE12, PE13, PE14, PE2, PE5, PE6};
 
-#[cfg(feature = "stm32f429")]
+#[cfg(any(feature = "stm32f429"))]
 use gpio::gpiof::{PF11, PF7, PF8, PF9};
 
-#[cfg(feature = "stm32f429")]
-use gpio::gpiog::{PG12, PG13, PG14};
+#[cfg(any(feature = "stm32f429"))]
+use gpio::gpiog::{PG12, PG13};
+#[cfg(any(feature = "stm32f429"))]
+use gpio::gpiog::{PG14};
 
-#[cfg(feature = "stm32f429")]
+#[cfg(any(feature = "stm32f429"))]
 use gpio::gpioh::{PH6, PH7};
 
 #[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
 use gpio::gpioi::{PI1, PI2, PI3};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 use gpio::{Alternate, AF5, AF6};
-
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
-use gpio::{Alternate, AF5, AF6, AF7};
+#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+use gpio::{AF7};
 
 use rcc::Clocks;
 use time::Hertz;
@@ -110,6 +119,7 @@ macro_rules! pins {
     }
 }
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 pins! {
     SPI1:
         SCK: [
@@ -144,7 +154,10 @@ pins! {
             PB15<Alternate<AF5>>,
             PC3<Alternate<AF5>>
         ]
+}
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+pins! {
     SPI3:
         SCK: [
             NoSck,
@@ -205,6 +218,28 @@ pins! {
         SCK: [PC7<Alternate<AF5>>]
         MISO: []
         MOSI: []
+}
+
+#[cfg(feature = "stm32f412")]
+pins! {
+    SPI5:
+        SCK: [
+            NoSck,
+            PB0<Alternate<AF6>>
+        ]
+        MISO: [
+            NoMiso,
+            PA12<Alternate<AF6>>
+        ]
+        MOSI: [
+            NoMosi,
+            PA10<Alternate<AF6>>,
+            PB8<Alternate<AF6>>
+        ]
+}
+
+#[cfg(feature = "stm32f412")]
+pins! {
     SPI3:
         SCK: [PB12<Alternate<AF7>>]
         MISO: []
@@ -215,21 +250,14 @@ pins! {
         MOSI: [PA1<Alternate<AF5>>]
     SPI5:
         SCK: [
-            NoSck,
-            PB0<Alternate<AF6>>,
             PE2<Alternate<AF6>>,
             PE12<Alternate<AF6>>
         ]
         MISO: [
-            NoMiso,
-            PA12<Alternate<AF6>>,
             PE5<Alternate<AF6>>,
             PE13<Alternate<AF6>>
         ]
         MOSI: [
-            NoMosi,
-            PA10<Alternate<AF6>>,
-            PB8<Alternate<AF6>>,
             PE6<Alternate<AF6>>,
             PE14<Alternate<AF6>>
         ]
@@ -398,12 +426,15 @@ macro_rules! hal {
     }
 }
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 hal! {
     SPI1: (spi1, apb2enr, spi1en, pclk2),
     SPI2: (spi2, apb1enr, spi2en, pclk1),
+}
+#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+hal! {
     SPI3: (spi3, apb1enr, spi3en, pclk1),
 }
-
 #[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
 hal! {
     SPI4: (spi4, apb2enr, spi4en, pclk2),

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,67 +4,77 @@ use hal;
 pub use hal::spi::{Mode, Phase, Polarity};
 use nb;
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{RCC, SPI1, SPI2};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{SPI3};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{SPI4};
 
-#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{SPI5};
 
-#[cfg(any(feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{SPI6};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioa::{PA5, PA6, PA7};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 use gpio::gpioa::{PA10, PA12};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 use gpio::gpioa::{PA1, PA11};
+#[cfg(any(feature = "stm32f413", feature = "stm32f423", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+use gpio::gpioa::{PA9};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpiob::{PB10, PB13, PB14, PB15, PB3, PB4, PB5};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f446"))]
 use gpio::gpiob::{PB0};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 use gpio::gpiob::{PB8};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 use gpio::gpiob::{PB12};
+#[cfg(any(feature = "stm32f446"))]
+use gpio::gpiob::{PB2};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioc::{PC2, PC3};
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioc::{PC10, PC11, PC12};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f446"))]
 use gpio::gpioc::{PC7};
+#[cfg(any(feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+use gpio::gpioc::{PC1};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpiod::{PD3, PD6};
+#[cfg(any(feature = "stm32f446"))]
+use gpio::gpiod::{PD0};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioe::{PE12, PE13, PE14, PE2, PE5, PE6};
 
-#[cfg(any(feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpiof::{PF11, PF7, PF8, PF9};
 
-#[cfg(any(feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpiog::{PG12, PG13};
-#[cfg(any(feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpiog::{PG14};
+#[cfg(any(feature = "stm32f446"))]
+use gpio::gpiog::{PG11};
 
-#[cfg(any(feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioh::{PH6, PH7};
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f415", feature = "stm32f417", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::gpioi::{PI1, PI2, PI3};
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use gpio::{Alternate, AF5, AF6};
-#[cfg(any(feature = "stm32f411", feature = "stm32f412"))]
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f446"))]
 use gpio::{AF7};
 
 use rcc::Clocks;
@@ -119,7 +129,7 @@ macro_rules! pins {
     }
 }
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pins! {
     SPI1:
         SCK: [
@@ -156,7 +166,7 @@ pins! {
         ]
 }
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pins! {
     SPI3:
         SCK: [
@@ -176,7 +186,7 @@ pins! {
         ]
 }
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 pins! {
     SPI2:
         SCK: [PD3<Alternate<AF5>>]
@@ -204,7 +214,7 @@ pins! {
         ]
 }
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f415", feature = "stm32f417", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 pins! {
     SPI2:
         SCK: [PI1<Alternate<AF5>>]
@@ -212,7 +222,7 @@ pins! {
         MOSI: [PI3<Alternate<AF5>>]
 }
 
-#[cfg(any(feature = "stm32f412", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f446"))]
 pins! {
     SPI2:
         SCK: [PC7<Alternate<AF5>>]
@@ -220,7 +230,7 @@ pins! {
         MOSI: []
 }
 
-#[cfg(feature = "stm32f412")]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 pins! {
     SPI5:
         SCK: [
@@ -238,7 +248,7 @@ pins! {
         ]
 }
 
-#[cfg(feature = "stm32f412")]
+#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423"))]
 pins! {
     SPI3:
         SCK: [PB12<Alternate<AF7>>]
@@ -263,7 +273,15 @@ pins! {
         ]
 }
 
-#[cfg(feature = "stm32f429")]
+#[cfg(any(feature = "stm32f413", feature = "stm32f423"))]
+pins! {
+    SPI2:
+        SCK: [PA9<Alternate<AF5>>]
+        MISO: [PA12<Alternate<AF5>>]
+        MOSI: [PA10<Alternate<AF5>>]
+}
+
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 pins! {
     SPI5:
         SCK: [
@@ -295,6 +313,39 @@ pins! {
             NoMosi,
             PG14<Alternate<AF5>>
         ]
+}
+
+#[cfg(any(feature = "stm32f446"))]
+pins! {
+    SPI2:
+        SCK: [PA9<Alternate<AF5>>]
+        MISO: []
+        MOSI: [PC1<Alternate<AF7>>]
+
+    SPI3:
+        SCK: []
+        MISO: []
+        MOSI: [
+            PB0<Alternate<AF7>>,
+            PB2<Alternate<AF7>>,
+            PD0<Alternate<AF6>>
+        ]
+
+    SPI4:
+        SCK: [PG11<Alternate<AF6>>]
+        MISO: [
+            PG12<Alternate<AF6>>,
+            PD0<Alternate<AF5>>
+        ]
+        MOSI: [PG13<Alternate<AF6>>]
+}
+
+#[cfg(any(feature = "stm32f469", feature = "stm32f479"))]
+pins! {
+    SPI2:
+        SCK: [PA9<Alternate<AF5>>]
+        MISO: []
+        MOSI: [PC1<Alternate<AF5>>]
 }
 
 #[derive(Debug)]
@@ -426,24 +477,24 @@ macro_rules! hal {
     }
 }
 
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     SPI1: (spi1, apb2enr, spi1en, pclk2),
     SPI2: (spi2, apb1enr, spi2en, pclk1),
 }
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     SPI3: (spi3, apb1enr, spi3en, pclk1),
 }
-#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     SPI4: (spi4, apb2enr, spi4en, pclk2),
 }
-#[cfg(any(feature = "stm32f411", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     SPI5: (spi5, apb2enr, spi5en, pclk2),
 }
-#[cfg(feature = "stm32f429")]
+#[cfg(any(feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     SPI6: (spi6, apb2enr, spi6en, pclk2),
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -7,11 +7,15 @@ use hal::timer::{CountDown, Periodic};
 use nb;
 use void::Void;
 
-use stm32::{RCC, TIM1, TIM5, TIM9, TIM11};
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+use stm32::RCC;
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+use stm32::{TIM1, TIM5, TIM9, TIM11};
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 use stm32::{TIM2, TIM3, TIM4, TIM10};
-#[cfg(any(feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
-use stm32::{TIM6, TIM7, TIM8, TIM12, TIM13, TIM14};
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+use stm32::{TIM6};
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+use stm32::{TIM7, TIM8, TIM12, TIM13, TIM14};
 
 use rcc::{Clocks};
 use time::Hertz;
@@ -175,6 +179,7 @@ macro_rules! hal {
     }
 }
 
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr, pclk2, ppre2),
     TIM5: (tim5, tim5en, tim5rst, apb1enr, apb1rstr, pclk1, ppre1),
@@ -182,8 +187,7 @@ hal! {
     TIM11: (tim11, tim11en, tim11rst, apb2enr, apb2rstr, pclk2, ppre2),
 }
 
-// available on all stm32f4 except stm32f410
-#[cfg(any(feature = "stm32f401", feature = "stm32f407", feature = "stm32f412", feature = "stm32f429", feature = "stm32f411"))]
+#[cfg(any(feature = "stm32f401", feature = "stm32f405", feature = "stm32f407", feature = "stm32f411", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, pclk1, ppre1),
     TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, pclk1, ppre1),
@@ -191,9 +195,13 @@ hal! {
     TIM10: (tim10, tim10en, tim10rst, apb2enr, apb2rstr, pclk2, ppre2),
 }
 
-#[cfg(any(feature = "stm32f407", feature = "stm32f412", feature = "stm32f429"))]
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f410", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
 hal! {
     TIM6: (tim6, tim6en, tim6rst, apb1enr, apb1rstr, pclk1, ppre1),
+}
+
+#[cfg(any(feature = "stm32f405", feature = "stm32f407", feature = "stm32f412", feature = "stm32f413", feature = "stm32f415", feature = "stm32f417", feature = "stm32f423", feature = "stm32f427", feature = "stm32f429", feature = "stm32f437", feature = "stm32f439", feature = "stm32f446", feature = "stm32f469", feature = "stm32f479"))]
+hal! {
     TIM7: (tim7, tim7en, tim7rst, apb1enr, apb1rstr, pclk1, ppre1),
     TIM8: (tim8, tim8en, tim8rst, apb2enr, apb2rstr, pclk2, ppre2),
     TIM12: (tim12, tim12en, tim12rst, apb1enr, apb1rstr, pclk1, ppre1),


### PR DESCRIPTION
This patch series adds support for every existing stm32f4 devices. It is not complete yet. Serial and I2C still needs to be done. Moreover, it requires a new release of the stm32f4 crates for some devices.

Anyway, you may still want to merge the patch series, except for the last patch, which is the one actually enabling all those new devices.